### PR TITLE
Move buttons demo page to `/dev/buttons`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,12 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# jumbocode.org
 
-## Getting Started
-
-First, run the development server:
+## Local development
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Conventions
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Examples for standalone components can be put under on `/dev/*` pages to preview them. (E.g. a page showing different button configurations.)

--- a/app/dev/buttons/page.tsx
+++ b/app/dev/buttons/page.tsx
@@ -1,0 +1,31 @@
+import Button from "@/components/button";
+import { EnvelopeIcon } from "@heroicons/react/24/outline";
+
+export default function Home() {
+  return (
+    <div className="p-4 space-y-4 bg-black">
+      <Button
+        text="Email Us"
+        route="/testing"
+        variant="primary"
+        icon={EnvelopeIcon}
+      />
+
+      <Button
+        text="Email Us"
+        route="/testing"
+        variant="secondary"
+        icon={EnvelopeIcon}
+      />
+
+      <Button
+        text="Email Us"
+        route="/testing"
+        variant="ghost"
+        icon={EnvelopeIcon}
+      />
+
+      <Button text="Email Us" route="/testing" variant="primary" />
+    </div>
+  );
+}

--- a/components/button.tsx
+++ b/components/button.tsx
@@ -1,0 +1,31 @@
+import clsx from "clsx";
+
+export default function Button({
+  text,
+  route,
+  variant,
+  icon = undefined,
+}: {
+  text: string;
+  route: string;
+  variant: "primary" | "secondary" | "ghost";
+  icon?: React.ElementType;
+}) {
+  const Icon = icon;
+  return (
+    <a
+      href={route}
+      className={clsx(
+        "block max-w-max px-4 py-2 rounded-lg font-semibold",
+        "flex items-center gap-2",
+        "hover:ring-2 hover:ring-offset-2 hover:ring-offset-black transition-shadow duration-200",
+        variant === "primary" && "bg-brand text-gray-900 hover:ring-brand",
+        variant === "secondary" && "bg-white text-gray-900 hover:ring-white",
+        variant === "ghost" && "text-white hover:ring-white"
+      )}
+    >
+      {Icon && <Icon className="w-4 h-4" />}
+      <span>{text}</span>
+    </a>
+  );
+}


### PR DESCRIPTION
# Description

Currently the buttons I built are hanging out on `/`, the home page. I'm just moving them to `/dev/buttons`, so we can build out actual pages on the homepage. 

## Issues

<!-- Reference the issue that you're working on (if exists) -->
<!-- When you references an issue, Github will automatically link the PR to Github -->
<!-- For example, "Resolve #1" links your PR to the first issue -->
<!-- For a full list of keywords, see here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## Screenshots

<!-- If you're making UI changes, please include screenshots and describe the expected user flow. -->

## Test

<!-- Describe how we can test your code -->

## Possible Downsides

<!-- List anything we should be aware of -->

## Additional Documentations

<!-- Describe any documentations or references that would be helpful for us to review your code -->
